### PR TITLE
Compatibility for aggressive server resource pack requirements

### DIFF
--- a/src/main/java/dev/furq/resourcepackcached/mixin/ResourcePackHandshakeMixin.java
+++ b/src/main/java/dev/furq/resourcepackcached/mixin/ResourcePackHandshakeMixin.java
@@ -1,0 +1,35 @@
+package dev.furq.resourcepackcached.mixin;
+
+import com.google.common.hash.HashCode;
+import dev.furq.resourcepackcached.utils.CachingUtils;
+import net.minecraft.client.multiplayer.ClientCommonPacketListenerImpl;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.common.ClientboundResourcePackPushPacket;
+import net.minecraft.network.protocol.common.ServerboundResourcePackPacket;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ClientCommonPacketListenerImpl.class)
+public abstract class ResourcePackHandshakeMixin {
+
+    @Shadow
+    public abstract void send(Packet<?> packet);
+
+    @Inject(method = "handleResourcePackPush", at = @At("HEAD"))
+    private void spoofResourcePackPackets(ClientboundResourcePackPushPacket packet, CallbackInfo ci) {
+        String hash = packet.hash();
+        if (hash != null && !hash.isEmpty()) {
+            try {
+                if (CachingUtils.isCachedResourcePack(packet.id(), HashCode.fromString(hash))) {
+                    this.send(new ServerboundResourcePackPacket(packet.id(), ServerboundResourcePackPacket.Action.ACCEPTED));
+                    this.send(new ServerboundResourcePackPacket(packet.id(), ServerboundResourcePackPacket.Action.SUCCESSFULLY_LOADED));
+                }
+            } catch (Exception ignored) {
+                // Ignore invalid hashes etc.
+            }
+        }
+    }
+}

--- a/src/main/java/dev/furq/resourcepackcached/mixin/ServerPackManagerMixin.java
+++ b/src/main/java/dev/furq/resourcepackcached/mixin/ServerPackManagerMixin.java
@@ -46,7 +46,6 @@ abstract class ServerPackManagerMixin {
             latestPacks.put(id, downloadPath);
 
             if (CachingUtils.isCachedResourcePack(id, hashCode)) {
-                this.packLoadFeedback.reportFinalResult(id, PackLoadFeedback.FinalResult.APPLIED);
                 this.registerForUpdate();
                 ci.cancel();
             }

--- a/src/main/resources/rpc.mixins.json
+++ b/src/main/resources/rpc.mixins.json
@@ -8,6 +8,7 @@
   },
   "client": [
     "DownloadedPackSourceMixin",
-    "ServerPackManagerMixin"
+    "ServerPackManagerMixin",
+    "ResourcePackHandshakeMixin"
   ]
 }


### PR DESCRIPTION
Most large servers that require you to use a resource pack will kick you if the client doesn't tell the server __both__ that they ACCEPT the pack and that it was APPLIED.

The current code only told the server the pack was APPLIED, which is an issue because most servers listen to ACCEPT instead.

This PR sends both ACCEPT and APPLIED when the mod agrees that the current resource pack is cached, preventing the server kicking you.

Tested on FaceLand `beta.face.land`